### PR TITLE
Added @Text_Get_Nth_Index_Of and @Text_Get_Nth_Split_Chunk Util Functions

### DIFF
--- a/src/shared/text.xc
+++ b/src/shared/text.xc
@@ -70,3 +70,46 @@ function @Text_Truncate($text: text, $limit: number, $ending: text): text
 		return substring($text, 0, $trueLimit) & $ending
 		
 	return $text
+
+
+; Returns the index of the n-th occurrence of the given search string
+; $text: The text to search
+; $search: The given search string
+; $n: The number that determines which occurrence we're looking for
+function @Text_Get_Nth_Index_Of($text: text, $search: text, $n: number): number
+	if $n == 0
+		return 0
+	var $index = 0
+	while $index < size($text) && $n > 0
+		if $text.$index != $search.0
+			$index++
+		else
+			var $nextTextBlock = substring($text, $index, size($search))
+			if $nextTextBlock == $search
+				$n--
+				if $n > 0
+					$index += size($search)
+	if $n > 0
+		return -1
+	else
+		return $index
+
+
+; Returns what is between the n-th and n+1-th occurrence of the $splitter string
+; If the splitter is not contained at least n+1 times, "INVALID" is returned instead
+; $text: The text that is being split
+; $splitter: The split string
+; $n: The number that determines which occurrence we're looking for
+
+function @Text_Get_Nth_Split_Chunk($text: text, $splitter: text, $n: number): text
+	if @Text_Count($text, $splitter) < $n
+		return "INVALID"
+	var $startIndex = @Text_Get_Nth_Index_Of($text, $splitter, $n)
+	if $n > 0
+		$startIndex++
+	var $endIndex = @Text_Get_Nth_Index_Of($text, $splitter, $n+1) - 1
+
+	if $startIndex < 0
+		return "INVALID"
+
+	return @Text_Substring($text, $startIndex, $endIndex)

--- a/src/shared/text.xc
+++ b/src/shared/text.xc
@@ -76,7 +76,7 @@ function @Text_Truncate($text: text, $limit: number, $ending: text): text
 ; $text: The text to search
 ; $search: The given search string
 ; $n: The number that determines which occurrence we're looking for
-function @Text_Get_Nth_Index_Of($text: text, $search: text, $n: number): number
+function @Text_GetNthIndexOf($text: text, $search: text, $n: number): number
 	if $n == 0
 		return 0
 	var $index = 0
@@ -100,8 +100,7 @@ function @Text_Get_Nth_Index_Of($text: text, $search: text, $n: number): number
 ; $text: The text that is being split
 ; $splitter: The split string
 ; $n: The number that determines which occurrence we're looking for
-
-function @Text_Get_Nth_Split_Chunk($text: text, $splitter: text, $n: number): text
+function @Text_GetNthSplitChunk($text: text, $splitter: text, $n: number): text
 	if @Text_Count($text, $splitter) < $n
 		return "INVALID"
 	var $startIndex = @Text_Get_Nth_Index_Of($text, $splitter, $n)


### PR DESCRIPTION
Please check if what I did conforms with your code style and return value conventions. I did not find any "fail" cases in the other text utils, so I decided to put it as "INVALID" for text typed returns and -1 for number typed returns.

Testcases I used:

include "text.xc"

init
	var $str1 = "abcde:fg:123"
	var $first = (@Text_Get_Nth_Index_Of($str1, ":", 1))
	var $second = (@Text_Get_Nth_Index_Of($str1, ":", 4))
	print("@Text_Get_Nth_Index_Of(" & $str1 & ", ':', 1) ---> " & text($first))
	print("@Text_Get_Nth_Index_Of(" & $str1 & ", ':', 4) ---> " & text($second))
	
	

	var $chunk0 = @Text_Get_Nth_Split_Chunk( $str1, ":", 0)
	var $chunk1 = @Text_Get_Nth_Split_Chunk( $str1, ":", 1)
	var $chunk2 = @Text_Get_Nth_Split_Chunk( $str1, ":", 2)	
	var $chunk3 = @Text_Get_Nth_Split_Chunk( $str1, ":", 3)
			
	print("@Text_Get_Nth_Split_Chunk(" & $str1 & "), ':', 0) ---> " & $chunk0)
	print("@Text_Get_Nth_Split_Chunk(" & $str1 & "), ':', 1) ---> " & $chunk1)
	print("@Text_Get_Nth_Split_Chunk(" & $str1 & "), ':', 2) ---> " & $chunk2)
	print("@Text_Get_Nth_Split_Chunk(" & $str1 & "), ':', 3) ---> " & $chunk3)